### PR TITLE
docs: add API and contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing to SupportCarr
+
+Thank you for considering contributing to SupportCarr! Please follow these guidelines to help us review your changes quickly:
+
+1. Fork the repository and create your branch from `main`.
+2. Install dependencies with `npm install`.
+3. Run tests with `npm test` and lint with `npm run lint` before committing.
+4. Use descriptive commit messages and open a pull request with a clear summary of your changes.
+5. Ensure documentation and samples stay up to date.
+
+We appreciate your help in improving the project.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,68 @@
 # SupportCarr
-This is how supportcarr works
+
+SupportCarr is a ride-hailing platform API.
+
+## API Endpoints
+
+### GET /api/health
+Checks service status.
+
+**Sample Response**
+```json
+{"status":"ok"}
+```
+
+### POST /api/rides
+Creates a new ride request.
+
+**Sample Request**
+```json
+{
+  "rider_id": "abc123",
+  "pickup": {"lat": 37.77, "lng": -122.41},
+  "dropoff": {"lat": 37.79, "lng": -122.42}
+}
+```
+
+**Sample Response**
+```json
+{
+  "ride_id": "ride123",
+  "status": "REQUESTED"
+}
+```
+
+### GET /api/rides/{ride_id}
+Retrieves details for a specific ride.
+
+**Sample Response**
+```json
+{
+  "ride_id": "ride123",
+  "rider_id": "abc123",
+  "status": "REQUESTED",
+  "pickup": {"lat": 37.77, "lng": -122.41},
+  "dropoff": {"lat": 37.79, "lng": -122.42}
+}
+```
+
+## Configuration
+
+Environment variables configure the service:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `PORT` | Port for HTTP server | `3000` |
+| `DATABASE_URL` | Postgres connection string | – |
+| `REDIS_URL` | Redis connection string | – |
+| `JWT_SECRET` | Secret for signing JWT tokens | – |
+
+## Development Workflow
+
+1. Install dependencies: `npm install`
+2. Run tests: `npm test`
+3. Lint code: `npm run lint`
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on proposing changes.


### PR DESCRIPTION
## Summary
- document API endpoints with example requests/responses
- describe configuration options and developer workflow
- add contribution guidelines for new contributors

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a56467a03c832ca81be88d3f017a23