### PR TITLE
Add CI workflow for linting and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run lint
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ SupportCarr is a Node.js-based ride-hailing platform API that enables riders to 
 3. (Optional) Run tests: `npm test`
 4. (Optional) Lint code: `npm run lint`
 
+## Continuous Integration
+
+This project uses a GitHub Actions workflow located at `.github/workflows/ci.yml`.
+The workflow runs linting and unit tests on every push and pull request targeting the `main` branch.
+
 ## API Endpoints
 
 ### GET /api/health

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,7 @@
+export default [
+  {
+    files: ['**/*.js'],
+    languageOptions: { ecmaVersion: 2021 },
+    rules: {}
+  }
+];

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "node --test",
-    "start": "node index.js"
+    "start": "node index.js",
+    "lint": "npx eslint ."
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run lint and unit tests on pushes and PRs to `main`
- expose lint npm script and ESLint config
- document new CI workflow in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5ea726bb0832cbdd2a9e24840a473